### PR TITLE
Added in graphopts functionality to main()

### DIFF
--- a/speccurve.sthlp
+++ b/speccurve.sthlp
@@ -86,6 +86,8 @@
 	spacing and alignment. Panel() and controls() also allows labels(), where the user can specify alternative one-word labels for each entry in the panel
 	that appear on the y axis.{p_end}
 
+	{pstd}Main() also allows the suboption graphopts(), which can similarly be used specify {helpb twoway_options} modifying its style.
+
 	{marker preparation}{...}
 	{title:Saving or storing your models before using speccurve}
 


### PR DESCRIPTION
I added some code to main that allows you to specify a different marker style and such using a graphopts() suboption. I think there's a Windows/Linux different on line spacing that's causing most of the lines to be marked as changed in the files I modified--if you want to see the substantive changes I made before you merge the pull request, you can run git diff with the -w option to ignore the whitespace changes.